### PR TITLE
Teddit and LibReddit are dead, should be replaced by Redlib

### DIFF
--- a/nitter.example.conf
+++ b/nitter.example.conf
@@ -36,9 +36,9 @@ tokenCount = 10
 # Change default preferences here, see src/prefs_impl.nim for a complete list
 [Preferences]
 theme = "Nitter"
-replaceTwitter = "nitter.net"
+replaceTwitter = "xcancel.com"
 replaceYouTube = "piped.video"
-replaceReddit = "teddit.net"
+replaceReddit = "https://redlib.privacy.com.de"
 proxyVideos = true
 hlsPlayback = false
 infiniteScroll = false

--- a/src/prefs_impl.nim
+++ b/src/prefs_impl.nim
@@ -104,8 +104,8 @@ genPrefs:
       placeholder: "Piped hostname"
 
     replaceReddit(input, ""):
-      "Reddit -> Teddit/Libreddit"
-      placeholder: "Teddit hostname"
+      "Reddit -> "Redlib"
+      placeholder: "Redlib hostname"
 
 iterator allPrefs*(): Pref =
   for k, v in prefList:

--- a/tests/test_tweet.py
+++ b/tests/test_tweet.py
@@ -51,7 +51,7 @@ link = [
     ['nim_lang/status/1110499584852353024', [
         'nim-lang.org/araq/ownedrefs.…',
         'news.ycombinator.com/item?id…',
-        'teddit.net/r/programming…'
+        'redlib.privacy.com.de/r/programming…'
     ]],
     ['nim_lang/status/1125887775151140864', [
         'en.wikipedia.org/wiki/Nim_(p…'


### PR DESCRIPTION
See [Redlib github](https://github.com/redlib-org/redlib).
I choose redlib.privacy.com.de cause it has good reliability.
![redlib-instances](https://github.com/user-attachments/assets/7d7dd978-3216-4ccc-abe2-0897ad98e0c5)

I also changed redirect to xcancel.com, but didn't change other files.